### PR TITLE
Add link tiles to tag page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,15 @@ TODO:
 
 REWARDS:
   notification / score for # of views, votes, links, tags on uploaded content
+    - unique / total views show for link owner DONE
+    - toast notifications for 10 / 100 / 1000 unique views
+      - need message queue on backend
+      - when a link is updated, check for new milestones
+      - then add them to a message queue for the user
+      - when that user:
+        - logs in (easier)
+        - makes a request (needs middleware?)
+      - deliver the messages, then delete from queue
 
 STAGES:
   stage 1:
@@ -18,9 +27,28 @@ STAGES:
         - change list to table, allow sorting by new / top
         - add voting on tag page for tags
           - negative score removes the tag from the item
+      - sort by clip/youtube
         
+      - try tag page as tiled grid
+        - preview links on mouseover (add 1s delay to avoid spam?)
+        - mobile interface would be hold to preview, let go to enter, move off to deselect
+        
+        - need to make sure youtubeplayer fn works with multiple (or 1 that keeps remaking?) 
+        - how does it work for links and not videos? (tiny archive, autoscroll on mobile?)
+
       - related links functionality on link page
         - need some way to add links easily (search bar that searches title, url, tags, my links)
+
+  stage 2 bonus:
+    - find some way of making links permanent/unique
+      - auto-incrementing IDs sucks for server restarts or "unique" link feel
+      - wikipedia-style is perfect, maybe tag URLs are by name?
+      - authentic hashes would be too long (same length as actual URLs)
+        - compressed hash? 
+          most URL characters are lowercase letters
+
+      - add title to URL? 
+        even after hash as decoration
 
 
 -------------------

--- a/TODO.md
+++ b/TODO.md
@@ -79,6 +79,9 @@ BUGS:
     - nginx entry for www.sdwr.ca?
     - https?
     - blocked IP?
+  - being rate limited by archive.is
+    - remove preview for tiles?
+    - replace preview with thumbnail if fails to load
   - still getting cookie spam (just locally, probably per server restart)
     - looks like login makes 1 additional hash-named cookie
     - clear site cookies before login?

--- a/TODO.md
+++ b/TODO.md
@@ -30,16 +30,37 @@ STAGES:
       - sort by clip/youtube
         
       - try tag page as tiled grid
-        - preview links on mouseover (add 1s delay to avoid spam?)
+        - preview links on mouseover (add 1s delay to avoid spam?) DONE
         - mobile interface would be hold to preview, let go to enter, move off to deselect
+          (easier to test mobile when deployed)
         
-        - need to make sure youtubeplayer fn works with multiple (or 1 that keeps remaking?) 
+        - need to make sure youtubeplayer fn works with multiple (or 1 that keeps remaking?) DONE 
         - how does it work for links and not videos? (tiny archive, autoscroll on mobile?)
+          - need to pass scroll through the overlay into the embedding
+
+      - proper thumbnails:
+        - the individual thumbnail load is working very rarely right now
+        - need 2 resolutions, 1 for linkItem and 1 for linkPage (when embed doesn't load)
+        - save on server instead of fetching from link?
+          - async fetch on creating link
+            -
+          - if fails, retry:
+            - on load (needs lastTried, only retry once per hour/day )
+            - or periodically (need script running on server)
+          - sources:
+            - youtube can get from API
+            - others use openGraph (but most sites don't have??)
+            - worst case have 
+          - store in folder on server
+
+      - add opengraph images to pages, so it shows up on reddit etc
+        - should use thumbnail from actual site for link pages, maybe with watermark
 
       - related links functionality on link page
         - need some way to add links easily (search bar that searches title, url, tags, my links)
 
   stage 2 bonus:
+
     - find some way of making links permanent/unique
       - auto-incrementing IDs sucks for server restarts or "unique" link feel
       - wikipedia-style is perfect, maybe tag URLs are by name?
@@ -53,9 +74,14 @@ STAGES:
 
 -------------------
 BUGS:
-  - trying to add a link that already exists updates the time of the link
-    (does it use updatedAt time, date time?)
-    - should only be querying so does updatedAt get updated when retrieved?
+  - can't access site from bell cellular data
+    - does it want a DNS entry for www.sdwr.ca?
+    - nginx entry for www.sdwr.ca?
+    - https?
+    - blocked IP?
+  - still getting cookie spam (just locally, probably per server restart)
+    - looks like login makes 1 additional hash-named cookie
+    - clear site cookies before login?
   - tried to delete link with ID of 1, failed because other clips reference it
   - youtube player sometimes is called before its instantiated
 
@@ -307,6 +333,9 @@ TAG PAGE:
   - show list of links DONE
 
 BUGS:
+  - trying to add a link that already exists updates the time of the link DONE
+    (does it use updatedAt time, date time?)
+    - should only be querying so does updatedAt get updated when retrieved?
   - youtube player does not set end time correctly when moved by start time DONE
   (scattered logic for restarting loop vs skip to end)
     - should scrub in 3 conditions

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,8 @@ import ToastNotification from '@/components/ToastNotification.vue';
 import { isOnMobile } from '@/utils'
 import userLogin from '@/api/userLogin';
 
+import {stopPlayer } from '@/youtubeplayerapi';
+
 export default {
   name: 'App',
   components: {
@@ -33,9 +35,9 @@ export default {
     handleResize() {
       this.$store.dispatch('saveIsOnMobile', isOnMobile())
     },
-    async loadUser() {
-
-    },
+    handleLostFocus() {
+      stopPlayer();
+    }
   },
   async created() {
     await userLogin.loadUserAndLogin();
@@ -45,9 +47,11 @@ export default {
   },
   mounted() {
     window.addEventListener('resize', this.handleResize)
+    window.addEventListener('blur', this.handleLostFocus)
   },
   destroyed() {
     window.removeEventListener('resize', this.handleResize)
+    window.removeEventListener('blur', this.handleLostFocus)
   },
 }
 </script>

--- a/src/components/LinkTile.vue
+++ b/src/components/LinkTile.vue
@@ -1,0 +1,181 @@
+<template>
+<div class="link-tile" 
+  @mouseover="handleMouseover"
+  @mouseleave="handleMouseleave">
+
+  <div class="tile-content" v-if="showContent">
+    <div v-if="showYoutube" class="iframe" id="iframe"></div>
+    <PageEmbedding v-if="showOther" class="content-preview" :link="link"></PageEmbedding>
+  </div>
+
+  <div class="tile-overlay" v-if="!showContent">
+    <img class="tile-image" :src="thumbnail" alt="thumbnail">
+  </div>
+  <div class="loading-overlay" v-if="isLoading">
+    <div>Loading...</div>
+  </div>
+  <div class="click-overlay" @click.prevent="goToLink"></div>
+</div>
+</template>
+<script>
+import defaultThumbnail from '@/assets/tiny-default-thumbnail.png';
+import PageEmbedding from '@/components/PageEmbedding.vue';
+
+import { createPlayer, playPlayer, destroyPlayer, restartPlayer, setStartTime, setEndTime, setLoopTimes, setIsLoop } from '@/youtubeplayerapi';
+
+export default {
+  name: 'LinkTile',
+  components: {
+    PageEmbedding,
+  },
+  props: {
+    link: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      isHovered: false,
+      isLoading: false,
+
+      showYoutube: false,
+      showOther: false,
+      
+      youtubePlayer: null,
+    }
+  },
+  computed: {
+    showContent() {
+      return this.showYoutube || this.showOther;
+    },
+    linkIsYoutube() {
+      return this.link && this.link.domain === 'youtube.com';
+    },
+    thumbnail() {
+      return this.link.thumbnail || defaultThumbnail;
+    },
+  },
+  methods: {
+    handleMouseover() {
+      this.isHovered = true;
+      this.isLoading = true;
+
+      //only load content after user has hovered for a second
+      setTimeout(() => {
+        this.loadContent();
+      }, 1000);
+    },
+    handleMouseleave() {
+
+      if(this.youtubePlayer) {
+        destroyPlayer();
+      }
+
+      //stop showing content after mouse leaves
+      this.isHovered = false;
+      this.isLoading = false;
+      this.showYoutube = false;
+      this.showOther = false;
+    },
+    loadContent() {
+      this.isLoading = false;
+
+      if (!this.isHovered) return;
+      if (this.showContent) return;
+
+      if (this.linkIsYoutube) {
+        this.loadYoutube();
+      } else {
+        this.loadOther();
+      }
+    },
+    async loadYoutube() {
+      this.showYoutube = true;
+
+      await this.$nextTick();
+
+      this.youtubePlayer = await createPlayer(this.link.contentId, {controls: 0});
+      if (this.link.isClip) {
+        setLoopTimes(this.link.startTime, this.link.endTime);
+        setIsLoop(true);
+      } else {
+        setIsLoop(this.loopClip);
+        setEndTime(this.endTime);
+      }
+      playPlayer();
+    },
+    loadOther() {
+      this.showOther = true;
+    },
+    goToLink() {
+      console.log('going to link')
+      this.$router.push({ path: `/link/${this.link.id}`});
+    },
+  },
+}
+</script>
+<style scoped>
+
+.link-tile {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid #ccc;
+}
+.tile-content {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  background-color: #ddd;
+  overflow: hidden;
+}
+
+.iframe {
+  position: relative;
+  z-index: 3;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content-preview {
+  position: relative;
+  z-index: 3;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.tile-overlay {
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.loading-overlay {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.click-overlay {
+  position: absolute;
+  z-index: 4;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+  border: none;
+  pointer-events: auto;
+}
+</style>

--- a/src/components/LinkTile.vue
+++ b/src/components/LinkTile.vue
@@ -12,8 +12,10 @@
     <img class="tile-image" :src="thumbnail" alt="thumbnail">
   </div>
   <div class="loading-overlay" v-if="isLoading">
-    <div>Loading...</div>
+    <div class="spinner"></div>
   </div>
+  <!-- Click overlay is at highest z-level.
+      Eats the clicks and passes scrolls through to pageEmbedding -->
   <div class="click-overlay" @click.prevent="goToLink"></div>
 </div>
 </template>
@@ -167,6 +169,24 @@ export default {
   width: 100%;
   height: 100%;
 }
+.spinner {
+  border: 12px solid rgba(255, 255, 255, 0.3); /* Semi-transparent white border */
+  border-top: 12px solid #fff; /* Solid white for the spinner top */
+  border-radius: 50%;
+  width: 80px;
+  height: 80px;
+  animation: spin 1s linear infinite; 
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%); /* Keep the spinner centered */
+}
+
+@keyframes spin {
+  0% { transform: translate(-50%, -50%) rotate(0deg); }
+  100% { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
 .click-overlay {
   position: absolute;
   z-index: 4;

--- a/src/components/LinkTiles.vue
+++ b/src/components/LinkTiles.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="tiles-container">
+    <div class="tile" v-for="link in links" :key="link.id">
+      <LinkTile :link="link"></LinkTile>
+    </div>
+  </div>
+</template>
+
+<script>
+import LinkTile from '@/components/LinkTile.vue';
+
+export default {
+  name: 'LinkTiles',
+  components: {
+    LinkTile,
+  },
+  props: {
+    links: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+    }
+  },
+  computed: {
+    
+  },
+  methods: {
+    
+  }
+}
+</script>
+<style scoped>
+.tiles-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  width: 100%;
+  height: 100%;
+}
+.tile {
+  width: 200px;
+  height: 200px;
+  margin: 10px;
+}
+</style>

--- a/src/components/LinkTiles.vue
+++ b/src/components/LinkTiles.vue
@@ -36,13 +36,13 @@ export default {
 .tiles-container {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
   width: 100%;
   height: 100%;
+  align-content: flex-start;
 }
 .tile {
   width: 200px;
   height: 200px;
-  margin: 10px;
+  margin: 5px;
 }
 </style>

--- a/src/components/TagPage.vue
+++ b/src/components/TagPage.vue
@@ -1,16 +1,30 @@
 <template>
   <div class="linkpage">
-  <button @click="goBack()"> &lt; Go Back</button>
   <h1 class="tag-title">{{tag.name}}</h1>
+  <div class="header-tabs">
+    <div class="header-tab-button" @click="openList"
+      :class="{'selected': showList }">
+      <div>List</div>
+      <i class="fas" :class="{'fa-chevron-up': showList, 'fa-chevron-down': !showList}"></i>
+
+    </div>
+    <div class="header-tab-button" @click="openTiles"
+      :class="{'selected': showTiles }">
+      <div>Tiles</div>
+      <i class="fas" :class="{'fa-chevron-up': showTiles, 'fa-chevron-down': !showTiles}"></i>
+    </div>
+  </div>
     <div class="main-content">
       <div class="links">
-        <LinkTiles :links="links"></LinkTiles>
-        <div v-for="link in links" :key="link.id">
-          <LinkItem :link="link" 
-            @onClick="goToLink"
-            @onSave="saveLink"
-            @onUnsave="unsaveLink"
-          ></LinkItem>
+        <LinkTiles v-if="showTiles" :links="links"></LinkTiles>
+        <div v-if="showList" class="list-wrapper">
+          <div v-for="link in links" :key="link.id">
+            <LinkItem :link="link" 
+              @onClick="goToLink"
+              @onSave="saveLink"
+              @onUnsave="unsaveLink"
+            ></LinkItem>
+          </div>
         </div>
       </div>
     </div>
@@ -31,6 +45,10 @@ export default {
       tagId: null,
       tag: {name: ""},
       links: [],
+
+      //show/hide list and tiles
+      showList: true,
+      showTiles: false,
     }
   },
   computed: {
@@ -39,6 +57,15 @@ export default {
     }
   },
   methods: {
+    // UI state
+    openList() {
+      this.showList = true;
+      this.showTiles = false;
+    },
+    openTiles() {
+      this.showList = false;
+      this.showTiles = true;
+    },
     goToLink(link) {
       this.$router.push({ path: `/link/${link.id}`})
     },
@@ -90,8 +117,42 @@ export default {
   justify-content: center;
 }
 
+.links {
+  width: 100%;
+}
+
 .tag-title {
   
+}
+
+.header-tabs {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 50px;
+}
+
+.header-tab-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 33.33%;
+  height: 100%;
+  border-right: 1px solid #e0e0e0;
+  background-color: #f8f8f8;
+  border: 1px solid #e0e0e0;
+}
+
+.header-tab-button:hover {
+  background-color: #ececec;
+}
+
+.header-tab-button.selected {
+  background-color: #e0e0e0;
+}
+
+.header-tab-button i {
+  margin-left: 5px;
 }
 
 </style>

--- a/src/components/TagPage.vue
+++ b/src/components/TagPage.vue
@@ -4,6 +4,7 @@
   <h1 class="tag-title">{{tag.name}}</h1>
     <div class="main-content">
       <div class="links">
+        <LinkTiles :links="links"></LinkTiles>
         <div v-for="link in links" :key="link.id">
           <LinkItem :link="link" 
             @onClick="goToLink"
@@ -17,10 +18,12 @@
 </template>
 <script>
 import api from '@/api';
+import LinkTiles from '@/components/LinkTiles.vue';
 import LinkItem from '@/components/LinkItem.vue';
 
 export default {
   components: {
+    LinkTiles,
     LinkItem,
   },
   data() {

--- a/src/youtubeplayerapi.js
+++ b/src/youtubeplayerapi.js
@@ -1,7 +1,7 @@
 import store from "@/store";
 
 
-let player;
+let player = null;
 let startTime = 0;
 let endTime = -1;
 
@@ -22,12 +22,14 @@ const CHECK_INTERVAL = 250;
 //external functions
 export async function createPlayer(videoId, playerOptions) {
   resetPlayerVars();
+  destroyPlayer();
   store.dispatch('saveClipProgress', 0);
   return new Promise((resolve, reject) => {
     try {
       player = new window.YT.Player(
         'iframe',
         {
+          playerVars: playerOptions,
           videoId,
           height: '100%',
           width: '100%',
@@ -50,14 +52,32 @@ export async function createPlayer(videoId, playerOptions) {
 //so mute it to avoid sound at the beginning
 // temporary fix??
 export function playPlayer() {
+  if(!player) return;
+
   player.mute();
   player.playVideo();
   setTimeout(() => {
+    if(!player) return;
     player.unMute();
   }, 500)
 }
 
+export function stopPlayer() {
+  if(!player) return;
+
+  player.stopVideo();
+}
+
+export function destroyPlayer() {
+  if(!player) return;
+
+  player.destroy();
+  player = null;
+}
+
 export function scrubPlayerTo(time) {
+  if(!player) return;
+
   player.seekTo(time);
   player.mute();
   player.playVideo();
@@ -69,6 +89,8 @@ export function scrubPlayerTo(time) {
 //do the same thing to avoid audio hiccup
 //in the future, respect the user's volume settings?
 export function restartPlayer() {
+  if(!player) return;
+
   player.seekTo(startTime);
   player.mute();
   player.playVideo();
@@ -152,6 +174,8 @@ function shouldScrubPlayer() {
 }
 
 function calculateProgress() {
+  if(!player) return;
+
   let currentTime = player.getCurrentTime();
   let duration = endTime - startTime;
   let progress = (currentTime - startTime) / duration;

--- a/src/youtubeplayerapi.js
+++ b/src/youtubeplayerapi.js
@@ -95,6 +95,7 @@ export function restartPlayer() {
   player.mute();
   player.playVideo();
   setTimeout(() => {
+    if(!player) return;
     player.unMute();
   }, 500)
 }


### PR DESCRIPTION
- created linkTile, linkTiles components
 - shows preview of youtube video
 - with loading spinner and click-through to page
- added to tagPage, along with header tabs
- added some safety checks to youtubeplayerapi, including destroying player on close